### PR TITLE
Exclude env.mk from published hex packages

### DIFF
--- a/src/keccakf1600.app.src
+++ b/src/keccakf1600.app.src
@@ -2,6 +2,7 @@
 %% vim: ts=4 sw=4 ft=erlang noet
 {application, keccakf1600, [
 	{pkg_name, "keccakf1600_orig"},
+	{exclude_files, ["c_src/env.mk"]},
 	{description, "Keccak-f[1600] asynchronous port driver"},
 	{vsn, "2.1.0"},
 	{id, "git"},


### PR DESCRIPTION
The current hex package contains a generated env.mk file probably from your local machine that points to `/lib/Cellar/...` so compiling only works on macOS. This change makes it work again on linux, but you have to republish to the env.mk is not included in the package.